### PR TITLE
feat: Optionally allow alpha to be specified when clearing

### DIFF
--- a/source/renderxf/renderX_Core.cs
+++ b/source/renderxf/renderX_Core.cs
@@ -509,11 +509,11 @@ namespace renderX2
 
 
 
-        public unsafe void Clear(byte R, byte G, byte B)
+        public unsafe void Clear(byte R, byte G, byte B, byte A = 0xff)
         {
             lock (ThreadLock)
             {
-                _iClear = (((((byte)R) << 8) | (byte)G) << 8) | (byte)B;
+                _iClear = (((((A << 8) | R) << 8) | G) << 8) | B;
                 _iptr = (int*)DrawingBuffer;
 
                 Parallel.For(0, RenderHeight, _2D_Clear);


### PR DESCRIPTION
Since only 32 bpp is currently allowed, leaving the alpha set to 0 makes the images fully transparent.  This changes default behavior and sets the alpha channel to fully opaque by default, but the user can override with any value needed.